### PR TITLE
grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # configerator
 
+Simple module for implementing environment based configuration following the 12factor pattern.
+
 > This was adapted from the configuration implementation in [Pliny](https://github.com/interagent/pliny).
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -29,23 +29,12 @@ $ gem install configerator
     * Create `key`, set to `nil` if not present.
 * `override :key, :value`
     * Create `key`, set to `value` if not present.
-* `group :name { optional :key }`
-    * Creates a validator for all defined keys in the block &mdash; e.g. `name?`
 * `namespace :name { optional :key }`
     * Namespaces a collection of keys &mdash; e.g. `name_key`
     * Creates a validator for all defined keys in the block &mdash; e.g. `name?`
+    * Skip prefixing namespace for variables and methods with `prefix: false`
 
 ```ruby
-# group example
-group :server do
-    optional :bind
-    optional :port
-end
-
-# where
-server?
-#=> true # if bind? && port?
-
 # namespace example
 namespace :aws do
     required :token
@@ -55,7 +44,16 @@ end
 
 # where
 aws?
+
 #=> true # if aws_token? && aws_secret? && aws_region?
+namespace :etc do
+    required :foo
+    required :bar
+end
+
+# where
+etc?
+#=> true # if foo? && bar?
 ```
 
 ### Rails

--- a/README.md
+++ b/README.md
@@ -27,11 +27,36 @@ $ gem install configerator
     * Require a key, raise a `RuntimeError` if key is not supplied when `key` is requested.
 * `optional :key`
     * Create `key`, set to `nil` if not present.
-* `optional group_name: [ :key1, :key2 ]`
-    * Create keys &mdash; `key1` and `key2`
-    * Create group validor &mdash; `group_name?` &mdash; which returns true if all keys are set.
 * `override :key, :value`
     * Create `key`, set to `value` if not present.
+* `group :name { optional :key }`
+    * Creates a validator for all defined keys in the block &mdash; e.g. `name?`
+* `namespace :name { optional :key }`
+    * Namespaces a collection of keys &mdash; e.g. `name_key`
+    * Creates a validator for all defined keys in the block &mdash; e.g. `name?`
+
+```ruby
+# group example
+group :server do
+    optional :bind
+    optional :port
+end
+
+# where
+server?
+#=> true # if bind? && port?
+
+# namespace example
+namespace :aws do
+    required :token
+    required :secret
+    optional :region
+end
+
+# where
+aws?
+#=> true # if aws_token? && aws_secret? && aws_region?
+```
 
 ### Rails
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ end
 aws?
 
 #=> true # if aws_token? && aws_secret? && aws_region?
-namespace :etc do
+
+# namespace without prefix
+namespace :etc, prefix: false do
     required :foo, string
     required :bar, string
 end

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ $ gem install configerator
     * Require a key, raise a `RuntimeError` if key is not supplied when `key` is requested.
 * `optional :key`
     * Create `key`, set to `nil` if not present.
+* `optional group_name: [ :key1, :key2 ]`
+    * Create keys &mdash; `key1` and `key2`
+    * Create group validor &mdash; `group_name?` &mdash; which returns true if all keys are set.
 * `override :key, :value`
     * Create `key`, set to `value` if not present.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ $ gem install configerator
 ```ruby
 # namespace example
 namespace :aws do
-    required :token
-    required :secret
-    optional :region
+    required :token,  string
+    required :secret, string
+    optional :region, string
 end
 
 # where
@@ -47,8 +47,8 @@ aws?
 
 #=> true # if aws_token? && aws_secret? && aws_region?
 namespace :etc do
-    required :foo
-    required :bar
+    required :foo, string
+    required :bar, string
 end
 
 # where
@@ -75,9 +75,9 @@ require 'configurator'
 module Config
   extend Configerator
 
-  required :something
-  optional :anotherthing
-  override :port, 3000, int
+  required :something,    string
+  optional :anotherthing, string
+  override :port, 3000,   int
 end
 ```
 
@@ -100,9 +100,9 @@ require 'configerator'
 module Config
   extend Configerator
 
-  required :something
-  optional :anotherthing
-  override :port, 3000, int
+  required :something,    string
+  optional :anotherthing, string
+  override :port, 3000,   int
 end
 
 puts "#{Config.something}, and maybe: '#{Config.anotherthing}', all with #{Config.port}"
@@ -117,9 +117,9 @@ class Foo
   include Configerator
 
   def initialize
-    required :something
-    optional :anotherthing
-    override :port, 3000, int
+    required :something.    string
+    optional :anotherthing, string
+    override :port, 3000,   int
   end
 
   def run

--- a/configerator.gemspec
+++ b/configerator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'configerator'
-  s.version     = '0.0.4'
+  s.version     = '0.0.3'
   s.summary     = 'Configerator: A Config Helper'
   s.description = 'Simple module for implementing environment based configuration adapted from Pliny and following the 12factor pattern.'
   s.authors     = ['Joshua Mervine',     'Reid MacDonald']

--- a/lib/configerator/configerator.rb
+++ b/lib/configerator/configerator.rb
@@ -16,19 +16,14 @@ module Configerator
     create(name, value)
   end
 
-  def group name, &block
-    @processed = []
-    yield
-    instance_eval "def #{name}?; !!(#{@processed.join(' && ')}) end"
-  ensure
-    @processed = []
-  end
-
   def namespace namespace, prefix: true, &block
+    @processed = []
     @prefix = "#{namespace}_" if prefix
-    group(namespace) { yield }
+    yield
+    instance_eval "def #{namespace}?; !!(#{@processed.join(' && ')}) end"
   ensure
     @prefix = nil
+    @processed = []
   end
 
   def override(name, default, method=nil)

--- a/lib/configerator/configerator.rb
+++ b/lib/configerator/configerator.rb
@@ -77,12 +77,12 @@ module Configerator
 
   def create(name, value, error_on_load=true)
     name = "#{@prefix}#{name}"
-    var_name = :"@#{name}"
-    instance_variable_set(var_name, value)
+
+    instance_variable_set(:"@#{name}", value)
     instance_eval "def #{name}; @#{name} || (raise \"key not set '#{name}'\" unless #{error_on_load}) end"
-    instance_eval "def #{name}?; !!@#{name} end", __FILE__, __LINE__
+    instance_eval "def #{name}?; !!#{name} end", __FILE__, __LINE__
 
     @processed ||= []
-    @processed << var_name
+    @processed << name
   end
 end

--- a/test/configerator_test.rb
+++ b/test/configerator_test.rb
@@ -38,23 +38,26 @@ class TestConfigerator < Minitest::Test
   end
 
   def test_required
-    Config.send(:required, :test_required)
+    Config.required :test_required
 
     assert_equal Config.test_required, 'required'
     assert Config.test_required?
   end
 
   def test_required_on_load_false
-    Config.send(:required, :test_required2, error_on_load: false)
+    Config.required :test_required2, error_on_load: false
 
-    refute Config.send(:test_required2?)
     assert_raises RuntimeError do
-      Config.send(:test_required2)
+      Config.test_required2?
+    end
+
+    assert_raises RuntimeError do
+      Config.test_required2
     end
   end
 
   def test_required_with_method
-    Config.send(:required, :test_required, with_method)
+    Config.required :test_required, with_method
 
     assert_equal Config.test_required, 'method:required'
     assert Config.test_required?
@@ -62,24 +65,24 @@ class TestConfigerator < Minitest::Test
 
   def test_required_missing
     assert_raises KeyError do
-      Config.send(:required, :test_missing)
+      Config.required :test_missing
     end
   end
 
   def test_optional
-    Config.send(:optional, :test_optional)
+    Config.optional :test_optional
 
     assert_equal Config.test_optional, 'optional'
   end
 
   def test_optional_with_method
-    Config.send(:optional, :test_optional, with_method)
+    Config.optional :test_optional, with_method
 
     assert_equal Config.test_optional, 'method:optional'
   end
 
   def test_optional_missing
-    Config.send(:optional, :test_missing_optional)
+    Config.optional :test_missing_optional
 
     assert_nil Config.test_missing_optional
   end
@@ -123,19 +126,19 @@ class TestConfigerator < Minitest::Test
   end
 
   def test_override
-    Config.send(:override, :test_override, 'override_default')
+    Config.override :test_override, 'override_default'
 
     assert_equal Config.test_override, 'override'
   end
 
   def test_override_with_method
-    Config.send(:override, :test_override, 'override_default', with_method)
+    Config.override :test_override, 'override_default', with_method
 
     assert_equal Config.test_override, 'method:override'
   end
 
   def test_override_missing
-    Config.send(:override, :test_override_missing, 'override_default')
+    Config.override :test_override_missing, 'override_default'
 
     assert_equal Config.test_override_missing, 'override_default'
   end
@@ -154,7 +157,7 @@ class TestConfigerator < Minitest::Test
         end
 
       define_method(meth) do
-        Config.send(:required, meth, method)
+        Config.required meth, method
 
         assert_equal Config.send(meth), val
       end
@@ -162,7 +165,7 @@ class TestConfigerator < Minitest::Test
   end
 
   def test_url
-    Config.send(:required, :test_url, Config.url)
+    Config.required :test_url, Config.url
 
     assert_equal Config.test_url, URI.parse('https://99.com')
   end

--- a/test/configerator_test.rb
+++ b/test/configerator_test.rb
@@ -20,9 +20,6 @@ class TestConfigerator < Minitest::Test
     test_array_int: [ 9, 9 ],
     test_array: [ 'nine', 'nine' ],
 
-    test_group1: 'one',
-    test_group2: 'two',
-
     test_ns1: 'ns1',
     test_ns2: 'ns2',
 
@@ -87,42 +84,32 @@ class TestConfigerator < Minitest::Test
     assert_nil Config.test_missing_optional
   end
 
-  def test_group
-    Config.group :test_group do
-      Config.required :test_group1
-      Config.optional :test_group2
-      Config.override :test_group3, "three"
-    end
-
-    assert Config.test_group1
-    assert Config.test_group2
-    assert Config.test_group3
-    assert Config.test_group?
-  end
-
-  def test_group_missing
-    Config.group :test_group do
-      Config.required :test_group1
-      Config.optional :test_group2
-      Config.override :test_group3, "three"
-      Config.optional :test_group4
-    end
-
-    assert Config.test_group1
-    assert Config.test_group2
-    assert Config.test_group3
-    refute Config.test_group4
-    refute Config.test_group?
-  end
-
   def test_namespace
     Config.namespace :test do
-      Config.optional :ns1
+      Config.required :ns1
       Config.optional :ns2
+      Config.override :ns3, "three"
     end
 
     assert Config.test_ns1
     assert Config.test_ns2
+    assert Config.test_ns3
+    assert Config.test?
+  end
+
+  def test_namepsace_missing
+    Config.namespace :test do
+      Config.required :ns1
+      Config.optional :ns2
+      Config.override :ns3, "three"
+      Config.optional :ns4
+    end
+
+    assert Config.test_ns1
+    assert Config.test_ns2
+    assert Config.test_ns3
+    refute Config.test_ns4
+    refute Config.test?
   end
 
   def test_namespace_without_prefix
@@ -157,7 +144,7 @@ class TestConfigerator < Minitest::Test
   FIXTURES.each do |meth, val|
     caster = meth.to_s.gsub(/^test_/, '')
 
-    unless %w[ required optional override url ns1 ns2 group1 group2 ].include? caster
+    unless %w[ required optional override url ns1 ns2 ].include? caster
       method = \
         if caster =~ /_/
           parts = caster.split('_')

--- a/test/configerator_test.rb
+++ b/test/configerator_test.rb
@@ -19,6 +19,9 @@ class TestConfigerator < Minitest::Test
     test_url: 'https://99.com',
     test_array_int: [ 9, 9 ],
     test_array: [ 'nine', 'nine' ],
+
+    test_group1: 'one',
+    test_group2: 'two'
   }.freeze
 
   def setup
@@ -78,6 +81,23 @@ class TestConfigerator < Minitest::Test
     assert_nil Config.test_missing_optional
   end
 
+  def test_optional_grouping
+    Config.send(:optional, { test_group: [ :test_group1, :test_group2 ] })
+
+    assert Config.test_group1
+    assert Config.test_group2
+    assert Config.test_group?
+  end
+
+  def test_optional_grouping_missing
+    Config.send(:optional, { test_group: [ :test_group1, :test_group2, :test_group3 ] })
+
+    assert Config.test_group1
+    assert Config.test_group2
+    refute Config.test_group3
+    refute Config.test_group?
+  end
+
   def test_override
     Config.send(:override, :test_override, 'override_default')
 
@@ -102,7 +122,9 @@ class TestConfigerator < Minitest::Test
 
     unless %w[ required optional override url ].include? caster
       method = \
-        if caster =~ /_/
+        if caster =~ /group/
+          nil
+        elsif caster =~ /_/
           parts = caster.split('_')
           Config.send(parts.first.to_sym, Config.send(parts.last.to_sym))
         else

--- a/test/configerator_test.rb
+++ b/test/configerator_test.rb
@@ -135,17 +135,6 @@ class TestConfigerator < Minitest::Test
     assert Config.ns2
   end
 
-  def test_namepsace_without_group
-    Config.namespace :test, group: false do
-      Config.optional :ns1
-      Config.optional :ns2
-    end
-
-    assert Config.test_ns1
-    assert Config.test_ns2
-    refute Config.method_defined?(:test)
-  end
-
   def test_override
     Config.send(:override, :test_override, 'override_default')
 


### PR DESCRIPTION
Addressing issue #4 

Making `group` a casting proved to be unnecessary and far more difficult. Here we're simply checking to see if it's a hash and grouping if it is...

```
optional group_name: [ :grouped_key1, :grouped_key2 ]
```

cc @reidmix @joshuatobin 
