### PR TITLE
Dotenv environment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,23 @@ Configerator will autodetect [Dotenv](https://github.com/bkeepers/dotenv) or
 `dotenv-rails` and load it so that its environment variables are available
 as soon as the Configerator is ready.
 
-If you wish to bypass this autodetecting because of your apps specific needs,
-you can do this by requiring the library directly:
+NOTE: For Rails projects, Configerator uses the `dotenv-rails`
+[method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
+your `.env` files.  This may be of some surprise when it loads both your
+`.env` and `.env.test`.  This is because `dotenv-rails` loads environment
+files in this order:
+
+* .env.local
+* .env.$RAILS_ENV
+* .env
+
+We recommend that you use `.env.development` instead of `.env` for your
+development configurations.  and `.env.test` for your test configurations.
+One nice side effect is you will no longer have to `Dotenv.load(".env.test")`
+in your `spec_helper.rb`.
+
+Of course if this doesn't work for your needs you can bypass autodetecting
+and loading of Dotenv. You can do this by requiring the library directly:
 
 ```ruby
 require 'configerator/configerator'

--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ development configurations.  and `.env.test` for your test configurations.
 One nice side effect is you will no longer have to `Dotenv.load(".env.test")`
 in your `spec_helper.rb`.
 
+You can also use `.env` for shared configurations across all environments.
+
 Of course if this doesn't work for your needs you can bypass autodetecting
-and loading of Dotenv. You can do this by requiring the library directly:
+and loading of `Dotenv`. You can do this by requiring the library directly:
 
 ```ruby
 require 'configerator/configerator'

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ as soon as the Configerator is ready.
 > **NOTE**: For Rails projects, Configerator uses the `dotenv-rails`
 [method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
 your `.env` files.  This may be of some surprise when it loads both your
-`.env` and `.env.test` configurations.  This is because `dotenv-rails`
-loads environment files in this order:
+`.env` and `.env.test` configurations.
+
+This is because `dotenv-rails` loads environment files in this order:
 
 * .env.local
 * .env.$RAILS_ENV

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Configerator will autodetect [Dotenv](https://github.com/bkeepers/dotenv) or
 `dotenv-rails` and load it so that its environment variables are available
 as soon as the Configerator is ready.
 
-NOTE: For Rails projects, Configerator uses the `dotenv-rails`
+> **NOTE**: For Rails projects, Configerator uses the `dotenv-rails`
 [method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
 your `.env` files.  This may be of some surprise when it loads both your
 `.env` and `.env.test` configurations.  This is because `dotenv-rails`

--- a/README.md
+++ b/README.md
@@ -139,15 +139,15 @@ as soon as the Configerator is ready.
 NOTE: For Rails projects, Configerator uses the `dotenv-rails`
 [method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
 your `.env` files.  This may be of some surprise when it loads both your
-`.env` and `.env.test`.  This is because `dotenv-rails` loads environment
-files in this order:
+`.env` and `.env.test` configurations.  This is because `dotenv-rails`
+loads environment files in this order:
 
 * .env.local
 * .env.$RAILS_ENV
 * .env
 
 We recommend that you use `.env.development` instead of `.env` for your
-development configurations.  and `.env.test` for your test configurations.
+development configurations  and `.env.test` for your test configurations.
 One nice side effect is you will no longer have to `Dotenv.load(".env.test")`
 in your `spec_helper.rb`.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ as soon as the Configerator is ready.
 your `.env` files.  This may be of some surprise when it loads both your
 `.env` and `.env.test` configurations.
 
-This is because `dotenv-rails` loads environment files in this order:
+When `dotenv-rails` initializes, it loads environment files in this order:
 
 * .env.local
 * .env.$RAILS_ENV

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ as soon as the Configerator is ready.
 
 > **NOTE**: For Rails projects, Configerator uses the `dotenv-rails`
 [method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
-your `.env` files.  This may be of some surprise when it loads _both_ your
+your `.env` files.  This may be of some surprise when it loads **_both_** your
 `.env` and `.env.test` configurations.
 
 When `dotenv-rails` initializes, it loads environment files in this order:
@@ -150,7 +150,7 @@ When `dotenv-rails` initializes, it loads environment files in this order:
 We recommend that you use `.env.development` instead of `.env` for your
 development configurations  and `.env.test` for your test configurations.
 One nice side effect is you will no longer have to `Dotenv.load(".env.test")`
-in your `spec_helper.rb`.
+in your `test_helper.rb`/`spec_helper.rb`.
 
 You would then use `.env` for shared configurations across all environments.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ in your `spec_helper.rb`.
 
 You would then use `.env` for shared configurations across all environments.
 
+#### Disabling
+
 Of course if this doesn't work for your needs you can bypass autodetecting
 and loading of `Dotenv`. You can do this by requiring the library directly:
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ your `.env` files.  This may be of some surprise when it loads both your
 
 When `dotenv-rails` initializes, it loads environment files in this order:
 
-* .env.local
-* .env.$RAILS_ENV
-* .env
+* `.env.local`
+* `.env.$RAILS_ENV`
+* `.env`
 
 We recommend that you use `.env.development` instead of `.env` for your
 development configurations  and `.env.test` for your test configurations.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ development configurations  and `.env.test` for your test configurations.
 One nice side effect is you will no longer have to `Dotenv.load(".env.test")`
 in your `spec_helper.rb`.
 
-You can also use `.env` for shared configurations across all environments.
+You would then use `.env` for shared configurations across all environments.
 
 Of course if this doesn't work for your needs you can bypass autodetecting
 and loading of `Dotenv`. You can do this by requiring the library directly:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ as soon as the Configerator is ready.
 
 > **NOTE**: For Rails projects, Configerator uses the `dotenv-rails`
 [method to load](https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/rails.rb#L26-L32)
-your `.env` files.  This may be of some surprise when it loads both your
+your `.env` files.  This may be of some surprise when it loads _both_ your
 `.env` and `.env.test` configurations.
 
 When `dotenv-rails` initializes, it loads environment files in this order:


### PR DESCRIPTION
Adding docs to recommend using `.env.development` instead of `.env`

/cc @heroku/sre 
