### PR TITLE
putting a namespace on `rails g config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ etc?
 You can generate a config file, thusly:
 
 ```bash
-rails generate config
+rails generate configerator:config
 ```
 
 This will generate a configuration into `config/config.rb` with tips in comments.

--- a/lib/generators/config_generator.rb
+++ b/lib/generators/config_generator.rb
@@ -1,9 +1,0 @@
-class ConfigGenerator < Rails::Generators::Base
-  desc "Creates a Configerator-based file at config/config.rb"
-
-  source_root File.expand_path("../templates", __FILE__)
-
-  def create_config_file
-    copy_file "config.rb", "config/config.rb"
-  end
-end

--- a/lib/generators/configerator/config_generator.rb
+++ b/lib/generators/configerator/config_generator.rb
@@ -1,0 +1,11 @@
+module Configerator
+  class ConfigGenerator < Rails::Generators::Base
+    desc "Creates a Configerator-based file at config/config.rb"
+
+    source_root File.expand_path("../../templates", __FILE__)
+
+    def create_config_file
+      copy_file "config.rb", "config/config.rb"
+    end
+  end
+end


### PR DESCRIPTION
Now it's `rails g configerator:config`, and the title of the source gem in the help is correct too.
