### PR TITLE
Fix NameError when ActiveSupport is not available

### DIFF
--- a/configerator.gemspec
+++ b/configerator.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'configerator'
-  s.version     = '0.0.4'
+  s.version     = '0.0.5'
   s.summary     = 'Configerator: A Config Helper'
   s.description = 'Simple module for implementing environment based configuration adapted from Pliny and following the 12factor pattern.'
   s.authors     = ['Joshua Mervine',     'Reid MacDonald']

--- a/lib/configerator.rb
+++ b/lib/configerator.rb
@@ -11,7 +11,7 @@ require 'configerator/configerator'
 
 begin
   require 'dotenv/rails-now'
-rescue LoadError
+rescue LoadError, NameError
   # dotenv-rails not available
 end
 


### PR DESCRIPTION
Fixes https://github.com/heroku/configerator/issues/15